### PR TITLE
Clean up: electrode array usage

### DIFF
--- a/schemas/device/electrodeArrayUsage.schema.tpl.json
+++ b/schemas/device/electrodeArrayUsage.schema.tpl.json
@@ -1,11 +1,6 @@
 {
   "_type": "https://openminds.ebrains.eu/ephys/ElectrodeArrayUsage",
-  "_categories": [
-    "deviceUsage"
-  ],
-  "required": [
-    "device"
-  ],
+  "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "properties": {
     "anatomicalLocation": {
       "type": "array",
@@ -31,21 +26,7 @@
       "_linkedTypes": [
         "https://openminds.ebrains.eu/ephys/ElectrodeArray"
       ]
-    },
-    "lookupLabel": {
-      "type": "string",
-      "_instruction": "Enter a lookup label for this device usage that may help you to find this instance more easily."
-    },    
-    "metadataLocation": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all files or file bundles containing additional information about the usage of this device.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/File",
-        "https://openminds.ebrains.eu/core/FileBundle"
-      ]
-    },    
+    },   
     "spatialLocation": {
       "type": "array",
       "minItems": 2,
@@ -63,13 +44,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "usedSpecimen": {
-      "_instruction": "Add the state of the tissue sample or subject that this electrode array was used on.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/SubjectState",
-        "https://openminds.ebrains.eu/core/TissueSampleState"
-      ]
     }
   }
 }

--- a/schemas/device/electrodeArrayUsage.schema.tpl.json
+++ b/schemas/device/electrodeArrayUsage.schema.tpl.json
@@ -2,16 +2,25 @@
   "_type": "https://openminds.ebrains.eu/ephys/ElectrodeArrayUsage",
   "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
   "properties": {
-    "anatomicalLocation": {
+    "anatomicalLocationOfArray": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all anatomical entities that describe the semantic location of the contact point(s) of the electrode array best.",
+      "_instruction": "Add all anatomical entities that semantically best describe the overall anatomical location of the electrode array.",
       "_linkedCategories": [
         "anatomicalLocation"
       ]
     },
-    "contactResistance": {
+    "anatomicalLocationOfElectrodes": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "_instruction": "Add all anatomical entities that semantically best describe the anatomical location of each electrode contact of this array during its use, in the same order that the electrode identifiers for this electrode array have been specified.",
+      "_linkedCategories": [
+        "anatomicalLocation"
+      ]
+    },
+    "contactResistances": {
       "type": "array",
       "minItems": 2,
       "uniqueItems": true,
@@ -27,7 +36,7 @@
         "https://openminds.ebrains.eu/ephys/ElectrodeArray"
       ]
     },   
-    "spatialLocation": {
+    "spatialLocationOfElectrodes": {
       "type": "array",
       "minItems": 2,
       "uniqueItems": true,
@@ -40,7 +49,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Enter the identifiers of all electrodes during the use of this electrode array.",
+      "_instruction": "Enter the identifiers of all electrodes that are actually in use for this array.",
       "items": {
         "type": "string"
       }

--- a/schemas/device/electrodeArrayUsage.schema.tpl.json
+++ b/schemas/device/electrodeArrayUsage.schema.tpl.json
@@ -4,51 +4,29 @@
     "deviceUsage"
   ],
   "required": [
-    "electrodeArray"
+    "device"
   ],
   "properties": {
-    "additionalInformation": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add one or several files containing any additional information about this the electrode array.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/File",
-        "https://openminds.ebrains.eu/core/FileBundle"
-      ]
-    },
     "anatomicalLocation": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all anatomical entities in which this electrode array is located.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation",
-        "https://openminds.ebrains.eu/sands/CustomAnatomicalEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntity",
-        "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
+      "_instruction": "Add all anatomical entities that describe the semantic location of the contact point(s) of the electrode array best.",
+      "_linkedCategories": [
+        "anatomicalLocation"
       ]
     },
     "contactResistance": {
       "type": "array",
       "minItems": 2,
       "uniqueItems": true,
-      "_instruction": "Enter the contact resistance of each electrode of this array, in the same order that has been specified by letrero identifier in electrode array card.",
+      "_instruction": "Enter the contact resistance for each electrode of this array during its use, in the same order that the electrode identifiers for this electrode array have been specified.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue",
         "https://openminds.ebrains.eu/core/QuantitativeValueRange"
       ]
-    },
-    "coordinatePoint": {
-      "type": "array",
-      "minItems": 2,
-      "uniqueItems": true,
-      "_instruction": "Add the central coordinate of each electrode of this array, in the same order that has been specified by electrode identifier in electrode array card.",
-      "_embeddedTypes": [
-        "https://openminds.ebrains.eu/sands/CoordinatePoint"
-      ]
-    },
-    "electrodeArray": {
+    },    
+    "device": {
       "_instruction": "Add the electrode array used.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/ephys/ElectrodeArray"
@@ -56,22 +34,41 @@
     },
     "lookupLabel": {
       "type": "string",
-      "_instruction": "Enter a lookup label for this electrode array usage."
+      "_instruction": "Enter a lookup label for this device usage that may help you to find this instance more easily."
+    },    
+    "metadataLocation": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all files or file bundles containing additional information about the usage of this device.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle"
+      ]
+    },    
+    "spatialLocation": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "_instruction": "Add all coordinate points that best describe the spatial location of each electrode contact of this array during its use, in the same order that the electrode identifiers for this electrode array have been specified.",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/sands/CoordinatePoint"
+      ]
     },
     "usedElectrode": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Enter the identifier of all used electrodes.",
+      "_instruction": "Enter the identifiers of all electrodes during the use of this electrode array.",
       "items": {
         "type": "string"
       }
     },
     "usedSpecimen": {
-      "_instruction": "Add the tissue or subject used with this electrode array usage",
+      "_instruction": "Add the state of the tissue sample or subject that this electrode array was used on.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/TissueSampleState",
-        "https://openminds.ebrains.eu/core/SubjectState"
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
       ]
     }
   }


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- renamed `coordinatePoint` to `spatialLocation` to avoid potential confusions with other properties around coordinates
- renamed `electrodeArray` to `device` to move this to requirement list on concept and reduce list of property names
- removed category because it is now inherited from concept

MAJOR changes:
- extends concept schema for device usage

SPECIAL ATTENTION:
- removed `additionalInformation` which is inherited from concept as `metadataLocation`
- removed `lookupLabel` which is inherited from concept
- replaced linked schemas for `anatomicalLocation` by a new category called `anatomicalLocation` (Note: Category not added to the schemas yet, but the following schemas will receive this category:
     - sands/CustomAnatomicalEntity
     - sands/ParcellationEntity
     - sands/ParcellationEntityVersion
     - controlledTerms/Organ
     - controlledTerms/OrganismSubstance
     - controlledTerms/UBERONParcellation
     - controlledTerms/SubcellularEntity)